### PR TITLE
Track method calls during initialization/load

### DIFF
--- a/lib/rotoscope/version.rb
+++ b/lib/rotoscope/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Rotoscope
-  VERSION = "0.3.2-braze"
+  VERSION = "0.3.3-braze"
 end


### PR DESCRIPTION
While investigating https://brazetechnology.slack.com/archives/CV6V9JHJ5/p1699376982372069 I found that we were only tracking method calls happening _within_ tests but not calls made during initialization/load. In this case it was [this call specifically](https://github.com/Appboy/platform/blob/develop/shared_code/lib/shared/appboy/communication/sms/service_provider_helper.rb#L82) that we didn't track which caused a missing callgraph entry that would have run the test that failed. As you can see, that code would only run when loading this file for the first time. 

With this change the callgraph for this test file went from having 8 entries to 44 entries, including the mapping to the `message_send_response_codes.rb` file which would have run the test since that file was modified. 

TODO: Link to platform-image-base change that updates version of rotoscope 
TODO: Link to platform change that makes use of this change.
TODO: Generate callgraph w/ this change to see resulting file size.
